### PR TITLE
Fix canonical URL in response body

### DIFF
--- a/lib/jekyll-crosspost-to-medium.rb
+++ b/lib/jekyll-crosspost-to-medium.rb
@@ -110,6 +110,9 @@ module Jekyll
       content.prepend("<h1>#{title}</h1>")
       content << "<p><i>This article was originally posted <a href=\"#{url}\" rel=\"canonical\">on my own site</a>.</i></p>"
 
+      # Save canonical URL
+      canonical_url = url
+
       # Strip domain name from the URL we check against
       url = url.sub(/^#{@site.config['url']}?/,'')
 
@@ -122,7 +125,7 @@ module Jekyll
           'tags'          => post.data['tags'],
           'publishStatus' => @settings['status'] || "public",
           'license'       => @settings['license'] || "all-rights-reserved",
-          'canonicalUrl'  => url
+          'canonicalUrl'  => canonical_url
         }
 
         crosspost_to_medium(payload)


### PR DESCRIPTION
Doh! Turns out, that by stripping the domain from the URL, and then submitting that stripped value as the `canonicalUrl`, means Medium will reject that request. So, let’s save a `canonical_url` value before we then strip the URL for recording in the cache.