### PR TITLE
Accept optional 'text' config for canonical link (closes #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ jekyll-crosspost_to_medium:
 
     The license your post is given when it is syndicated to Medium.
 
+* `text`
+
+    Default: `<p><i>This article was originally posted <a href=\"#{url}\" rel=\"canonical\">on my own site</a>.</i></p>`
+
+    Optionally provide a string to override the default text for the canonical link back to the source post. A `{{ url }}` placeholder should be provided to indicate where to put the canonical link, e.g., `Some <a href="{{ url }}">link</a>`
+
 ## A Note on Environment Variables
 
 If you are having problems setting up Environment Variables, check out these guides:

--- a/lib/jekyll-crosspost-to-medium.rb
+++ b/lib/jekyll-crosspost-to-medium.rb
@@ -107,12 +107,23 @@ module Jekyll
       content = content.gsub /href=(["'])\//, "href=\"\1#{@site.config['url']}/"
       content = content.gsub /src=(["'])\//, "src=\"\1#{@site.config['url']}/"
 
-      # Prepend the title and add a link back to originating site
-      content.prepend("<h1>#{title}</h1>")
-      content << "<p><i>This article was originally posted <a href=\"#{url}\" rel=\"canonical\">on my own site</a>.</i></p>"
-
       # Save canonical URL
       canonical_url = url
+
+      # Prepend the title and add a link back to originating site
+      content.prepend("<h1>#{title}</h1>")
+      # Append a canonical link and text
+      # TODO Accept a position option, e.g., top, bottom.
+      # 
+      # User the user's config if it exists
+      if @settings['text']
+          canonical_text = "#{@settings['text']}"
+          canonical_text = canonical_text.gsub /{{ url }}/, canonical_url
+      # Otherwise, use boilerplate
+      else 
+          canonical_text = "<p><i>This article was originally posted <a href=\"#{url}\" rel=\"canonical\">on my own site</a>.</i></p>"
+      end
+      content << canonical_text
 
       # Strip domain name from the URL we check against
       url = url.sub(/^#{@site.config['url']}?/,'')


### PR DESCRIPTION
Also, simple regex to swap out a ```{{ url }}``` placeholder to provide flexibility on what is linked in the string (as discussed in issue #13)