### PR TITLE
Strip HTML from post.title field.

### DIFF
--- a/lib/jekyll-crosspost-to-medium.rb
+++ b/lib/jekyll-crosspost-to-medium.rb
@@ -78,14 +78,14 @@ module Jekyll
 
               content = post.content
               url = "#{@site.config['url']}#{post.url}"
-              title = post.data['title']
-              
+              title = strip_tags(post.data['title'])
+
               published_at = backdate ? post.date : DateTime.now
 
               crosspost_payload(crossposted, post, content, title, url, published_at)
             end
           else
-            
+
             # post Jekyll commit 0c0aea3
             # https://github.com/jekyll/jekyll/commit/0c0aea3ad7d2605325d420a23d21729c5cf7cf88
             if defined? site.find_converter_instance
@@ -112,12 +112,12 @@ module Jekyll
               content = (Liquid::Template.parse content).render @site.site_payload
 
               url = "#{@site.config['url']}#{post.url}"
-              title = post.title
-              
+              title = strip_tags(post.title)
+
               published_at = backdate ? post.date : DateTime.now
 
               crosspost_payload(crossposted, post, content, title, url, published_at)
-              
+
             end
           end
         end


### PR DESCRIPTION
Since post.titles are allowed and can contain markup but Medium doesn’t recognize this and instead escapes this markup, it should be removed before being sent to Medium.

@aarongustafson I wasn’t able to test this and am not too familiar with Ruby, so if you could test this somehow (I couldn’t find an easy way and there’s no documentation here) it would be great. Sorry again for this, hope it’s fine for you despite this.